### PR TITLE
feat: support for remote extensions

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,6 +3,5 @@
 test/**
 .gitignore
 jsconfig.json
-.eslintrc.json
 resources/images/
 tools/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 All notable changes to the "workspace-explorer" extension will be documented in this file.
 
+## 2.2.0
+*  Updated extension config for remote development workflows. VSCode will first try to run the extension locally and fallback to the remote extension host. This enables desktop VSCode users to continue seeing their workspaces while using remote extensions.
+* Patched a bug where folder creation would not work when running a remote extension
+* Patched a bug where workspace creation would not work when running a remote extension
+
 ## 2.1.0
 * Added experimental support for opening workspaces via command palette. PR by @fhemberger.
 * Migrated Git repo from GitLab to GitHub

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ This extension is now published and supported under the name
 [workspace-explorer](https://marketplace.visualstudio.com/items?itemName=tomsaunders-code.workspace-explorer). If you have **vscode-workspace-explorer** please
 install this version instead, as **vscode-workspace-explorer** is no longer supported.
 
-## Release 2.1.0
+## Release 2.2.0
 
-In this release we've added experimental support for opening workspaces using the command palette. Courtesy of [@fhemberger](https://github.com/fhemberger).
+
+**Support for Remote SSH, Remote WSL, and Remote Containers extensions.** Workspace Explorer should now continue to display a list of workspaces for users of the desktop version of VSCode when using the [remote extensions](https://code.visualstudio.com/docs/remote/remote-overview). If you installed Workspace Explorer both on your local and remote machine, to take advantage of this feature you'll need to uninstall Workspace Explorer from the remote machine.
+
+In case you missed it, **2.1.0** brought experimental support for opening workspaces using the command palette. Courtesy of [@fhemberger](https://github.com/fhemberger).
 
 - `Ctrl-k w` - open a workspace in same window
 - `Ctrl-k Ctrl-w` - open a workspace in a new window
-
-Also, this release marks the migration of the project source code from GitLab to GitHub. You can now find the project at [sirfuzzalot/workspace-explorer](https://github.com/sirfuzzalot/workspace-explorer/). The default branch has changed from `master` to `main`.
 
 # Introduction
 
@@ -202,6 +203,11 @@ ${env:USERPROFILE}\my\windows\path
 ```
 
 # Release Notes
+
+## 2.2.0
+- Updated extension config for remote development workflows. VSCode will first try to run the extension locally and fallback to the remote extension host. This enables desktop VSCode users to continue seeing their workspaces while using [remote extensions](https://code.visualstudio.com/docs/remote/remote-overview)
+- Patched a bug where folder creation would not work when running a remote extension
+- Pathed a bug where workspace creation would not work when running a remote extension
 
 ## 2.1.0
 - Added experimental support for opening workspaces via command palette. PR by @fhemberger.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "workspace-explorer",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -14,18 +14,18 @@
             }
         },
         "@babel/helper-validator-identifier": {
-            "version": "7.14.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
-            "integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A==",
+            "version": "7.14.9",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+            "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g==",
             "dev": true
         },
         "@babel/highlight": {
-            "version": "7.14.0",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
-            "integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+            "version": "7.14.5",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
+            "integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.14.0",
+                "@babel/helper-validator-identifier": "^7.14.5",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -44,32 +44,38 @@
             }
         },
         "@eslint/eslintrc": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.0.tgz",
-            "integrity": "sha512-2ZPCc+uNbjV5ERJr+aKSPRwZgKd2z11x0EgLvb1PURmUrn9QNRXFqje0Ldq454PfAVyaJYyrDvvIKSFP4NnBog==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
+            "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
                 "debug": "^4.1.1",
                 "espree": "^7.3.0",
-                "globals": "^12.1.0",
+                "globals": "^13.9.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^3.13.1",
                 "minimatch": "^3.0.4",
                 "strip-json-comments": "^3.1.1"
-            },
-            "dependencies": {
-                "globals": {
-                    "version": "12.4.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
-                    "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
-                    "dev": true,
-                    "requires": {
-                        "type-fest": "^0.8.1"
-                    }
-                }
             }
+        },
+        "@humanwhocodes/config-array": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
+            "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+            "dev": true,
+            "requires": {
+                "@humanwhocodes/object-schema": "^1.2.0",
+                "debug": "^4.1.1",
+                "minimatch": "^3.0.4"
+            }
+        },
+        "@humanwhocodes/object-schema": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
+            "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+            "dev": true
         },
         "@tootallnate/once": {
             "version": "1.1.2",
@@ -84,15 +90,15 @@
             "dev": true
         },
         "@types/node": {
-            "version": "15.0.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.0.1.tgz",
-            "integrity": "sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==",
+            "version": "15.14.9",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-15.14.9.tgz",
+            "integrity": "sha512-qjd88DrCxupx/kJD5yQgZdcYKZKSIGBVDIBE1/LTGcNm3d2Np/jxojkdePDdfnBHJc5W7vSMpbJ1aB7p/Py69A==",
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.55.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.55.0.tgz",
-            "integrity": "sha512-49hysH7jneTQoSC8TWbAi7nKK9Lc5osQNjmDHVosrcU8o3jecD9GrK0Qyul8q4aGPSXRfNGqIp9CBdb13akETg==",
+            "version": "1.59.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.59.0.tgz",
+            "integrity": "sha512-Zg38rusx2nU6gy6QdF7v4iqgxNfxzlBlDhrRCjOiPQp+sfaNrp3f9J6OHIhpGNN1oOAca4+9Hq0+8u3jwzPMlQ==",
             "dev": true
         },
         "acorn": {
@@ -102,9 +108,9 @@
             "dev": true
         },
         "acorn-jsx": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-            "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true
         },
         "agent-base": {
@@ -189,9 +195,9 @@
             "dev": true
         },
         "azure-devops-node-api": {
-            "version": "10.2.2",
-            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-10.2.2.tgz",
-            "integrity": "sha512-4TVv2X7oNStT0vLaEfExmy3J4/CzfuXolEcQl/BRUmvGySqKStTG2O55/hUQ0kM7UJlZBLgniM0SBq4d/WkKow==",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-11.0.1.tgz",
+            "integrity": "sha512-YMdjAw9l5p/6leiyIloxj3k7VIvYThKjvqgiQn88r3nhT93ENwsoDS3A83CyJ4uTWzCZ5f5jCi6c27rTU5Pz+A==",
             "dev": true,
             "requires": {
                 "tunnel": "0.0.6",
@@ -286,9 +292,9 @@
             }
         },
         "chalk": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-            "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "requires": {
                 "ansi-styles": "^4.1.0",
@@ -337,30 +343,31 @@
             }
         },
         "cheerio": {
-            "version": "1.0.0-rc.6",
-            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.6.tgz",
-            "integrity": "sha512-hjx1XE1M/D5pAtMgvWwE21QClmAEeGHOIDfycgmndisdNgI6PE1cGRQkMGBcsbUbmEQyWu5PJLUcAOjtQS8DWw==",
+            "version": "1.0.0-rc.10",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+            "integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
             "dev": true,
             "requires": {
-                "cheerio-select": "^1.3.0",
-                "dom-serializer": "^1.3.1",
-                "domhandler": "^4.1.0",
+                "cheerio-select": "^1.5.0",
+                "dom-serializer": "^1.3.2",
+                "domhandler": "^4.2.0",
                 "htmlparser2": "^6.1.0",
                 "parse5": "^6.0.1",
-                "parse5-htmlparser2-tree-adapter": "^6.0.1"
+                "parse5-htmlparser2-tree-adapter": "^6.0.1",
+                "tslib": "^2.2.0"
             }
         },
         "cheerio-select": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.4.0.tgz",
-            "integrity": "sha512-sobR3Yqz27L553Qa7cK6rtJlMDbiKPdNywtR95Sj/YgfpLfy0u6CGJuaBKe5YE/vTc23SCRKxWSdlon/w6I/Ew==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+            "integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
             "dev": true,
             "requires": {
-                "css-select": "^4.1.2",
-                "css-what": "^5.0.0",
+                "css-select": "^4.1.3",
+                "css-what": "^5.0.1",
                 "domelementtype": "^2.2.0",
                 "domhandler": "^4.2.0",
-                "domutils": "^2.6.0"
+                "domutils": "^2.7.0"
             }
         },
         "color-convert": {
@@ -396,12 +403,6 @@
             "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
             "dev": true
         },
-        "contains-path": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-            "dev": true
-        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -420,9 +421,9 @@
             }
         },
         "css-select": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.2.tgz",
-            "integrity": "sha512-nu5ye2Hg/4ISq4XqdLY2bEatAcLIdt3OYGFc9Tm9n7VSlFBcfRv0gBNksHRgSdUDQGtN3XrZ94ztW+NfzkFSUw==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+            "integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
             "dev": true,
             "requires": {
                 "boolbase": "^1.0.0",
@@ -433,15 +434,15 @@
             }
         },
         "css-what": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
-            "integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+            "integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
             "dev": true
         },
         "debug": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-            "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "dev": true,
             "requires": {
                 "ms": "2.1.2"
@@ -478,13 +479,13 @@
             }
         },
         "dom-serializer": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
-            "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+            "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
             "dev": true,
             "requires": {
                 "domelementtype": "^2.0.1",
-                "domhandler": "^4.0.0",
+                "domhandler": "^4.2.0",
                 "entities": "^2.0.0"
             }
         },
@@ -504,9 +505,9 @@
             }
         },
         "domutils": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-            "integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+            "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
             "dev": true,
             "requires": {
                 "dom-serializer": "^1.0.1",
@@ -595,28 +596,31 @@
             "dev": true
         },
         "eslint": {
-            "version": "7.25.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.25.0.tgz",
-            "integrity": "sha512-TVpSovpvCNpLURIScDRB6g5CYu/ZFq9GfX2hLNIV4dSBKxIWojeDODvYl3t0k0VtMxYeR8OXPCFE5+oHMlGfhw==",
+            "version": "7.32.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
+            "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "7.12.11",
-                "@eslint/eslintrc": "^0.4.0",
+                "@eslint/eslintrc": "^0.4.3",
+                "@humanwhocodes/config-array": "^0.5.0",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
                 "debug": "^4.0.1",
                 "doctrine": "^3.0.0",
                 "enquirer": "^2.3.5",
+                "escape-string-regexp": "^4.0.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^2.1.0",
                 "eslint-visitor-keys": "^2.0.0",
                 "espree": "^7.3.1",
                 "esquery": "^1.4.0",
                 "esutils": "^2.0.2",
+                "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^5.0.0",
+                "glob-parent": "^5.1.2",
                 "globals": "^13.6.0",
                 "ignore": "^4.0.6",
                 "import-fresh": "^3.0.0",
@@ -625,7 +629,7 @@
                 "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
-                "lodash": "^4.17.21",
+                "lodash.merge": "^4.6.2",
                 "minimatch": "^3.0.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
@@ -634,9 +638,17 @@
                 "semver": "^7.2.1",
                 "strip-ansi": "^6.0.0",
                 "strip-json-comments": "^3.1.0",
-                "table": "^6.0.4",
+                "table": "^6.0.9",
                 "text-table": "^0.2.0",
                 "v8-compile-cache": "^2.0.3"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+                    "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+                    "dev": true
+                }
             }
         },
         "eslint-config-airbnb-base": {
@@ -651,78 +663,68 @@
             }
         },
         "eslint-import-resolver-node": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
-            "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
+            "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
             "dev": true,
             "requires": {
-                "debug": "^2.6.9",
-                "resolve": "^1.13.1"
+                "debug": "^3.2.7",
+                "resolve": "^1.20.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
                 }
             }
         },
         "eslint-module-utils": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-            "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.2.tgz",
+            "integrity": "sha512-QG8pcgThYOuqxupd06oYTZoNOGaUdTY1PqK+oS6ElF6vs4pBdk/aYxFVQQXzcrAqp9m7cl7lb2ubazX+g16k2Q==",
             "dev": true,
             "requires": {
-                "debug": "^2.6.9",
+                "debug": "^3.2.7",
                 "pkg-dir": "^2.0.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
-                },
-                "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
                 }
             }
         },
         "eslint-plugin-import": {
-            "version": "2.22.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
-            "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+            "version": "2.24.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.24.2.tgz",
+            "integrity": "sha512-hNVtyhiEtZmpsabL4neEj+6M5DCLgpYyG9nzJY8lZQeQXEn5UPW1DpUdsMHMXsq98dbNm7nt1w9ZMSVpfJdi8Q==",
             "dev": true,
             "requires": {
-                "array-includes": "^3.1.1",
-                "array.prototype.flat": "^1.2.3",
-                "contains-path": "^0.1.0",
+                "array-includes": "^3.1.3",
+                "array.prototype.flat": "^1.2.4",
                 "debug": "^2.6.9",
-                "doctrine": "1.5.0",
-                "eslint-import-resolver-node": "^0.3.4",
-                "eslint-module-utils": "^2.6.0",
+                "doctrine": "^2.1.0",
+                "eslint-import-resolver-node": "^0.3.6",
+                "eslint-module-utils": "^2.6.2",
+                "find-up": "^2.0.0",
                 "has": "^1.0.3",
+                "is-core-module": "^2.6.0",
                 "minimatch": "^3.0.4",
-                "object.values": "^1.1.1",
-                "read-pkg-up": "^2.0.0",
-                "resolve": "^1.17.0",
-                "tsconfig-paths": "^3.9.0"
+                "object.values": "^1.1.4",
+                "pkg-up": "^2.0.0",
+                "read-pkg-up": "^3.0.0",
+                "resolve": "^1.20.0",
+                "tsconfig-paths": "^3.11.0"
             },
             "dependencies": {
                 "debug": {
@@ -735,13 +737,12 @@
                     }
                 },
                 "doctrine": {
-                    "version": "1.5.0",
-                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-                    "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+                    "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
                     "dev": true,
                     "requires": {
-                        "esutils": "^2.0.2",
-                        "isarray": "^1.0.0"
+                        "esutils": "^2.0.2"
                     }
                 },
                 "ms": {
@@ -780,9 +781,9 @@
             }
         },
         "eslint-visitor-keys": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
-            "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+            "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
             "dev": true
         },
         "espree": {
@@ -912,9 +913,9 @@
             }
         },
         "flatted": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
-            "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.2.tgz",
+            "integrity": "sha512-JaTY/wtrcSyvXJl4IMFHPKyFur1sE9AUqc0QnhOaJ0CxHtAoIV8pYDzeEfAaNEtGkOfq4gr3LBFmdXW5mOQFnA==",
             "dev": true
         },
         "fs.realpath": {
@@ -993,26 +994,18 @@
             }
         },
         "globals": {
-            "version": "13.8.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.8.0.tgz",
-            "integrity": "sha512-rHtdA6+PDBIjeEvA91rpqzEvk/k3/i7EeNQiryiWuJH0Hw9cpyJMAt2jtbAwUaRdhD+573X4vWw6IcjKPasi9Q==",
+            "version": "13.11.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-13.11.0.tgz",
+            "integrity": "sha512-08/xrJ7wQjK9kkkRoI3OFUBbLx4f+6x3SGwcPvQ0QH6goFDrOU2oyAWrmh3dJezu65buo+HBMzAMQy6rovVC3g==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
-            },
-            "dependencies": {
-                "type-fest": {
-                    "version": "0.20.2",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-                    "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-                    "dev": true
-                }
             }
         },
         "graceful-fs": {
-            "version": "4.2.6",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-            "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+            "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
             "dev": true
         },
         "has": {
@@ -1041,6 +1034,15 @@
             "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
             "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
             "dev": true
+        },
+        "has-tostringtag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+            "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+            "dev": true,
+            "requires": {
+                "has-symbols": "^1.0.2"
+            }
         },
         "hosted-git-info": {
             "version": "2.8.9",
@@ -1119,6 +1121,17 @@
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
+        "internal-slot": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
+            "integrity": "sha512-O0DB1JC/sPyZl7cIo78n5dR7eUSwwpYPiXRhTzNxZVAMUuB8vlnRFyLxdrVToks6XPLVnFfbzaVd5WLjhgg+vA==",
+            "dev": true,
+            "requires": {
+                "get-intrinsic": "^1.1.0",
+                "has": "^1.0.3",
+                "side-channel": "^1.0.4"
+            }
+        },
         "is-arrayish": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -1147,9 +1160,9 @@
             "dev": true
         },
         "is-core-module": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.3.0.tgz",
-            "integrity": "sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==",
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
+            "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
             "dev": true,
             "requires": {
                 "has": "^1.0.3"
@@ -1247,6 +1260,12 @@
                 "esprima": "^4.0.0"
             }
         },
+        "json-parse-better-errors": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+            "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+            "dev": true
+        },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1300,14 +1319,14 @@
             "dev": true
         },
         "load-json-file": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-            "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
                 "strip-bom": "^3.0.0"
             }
         },
@@ -1333,10 +1352,10 @@
             "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
             "dev": true
         },
-        "lodash.flatten": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+        "lodash.merge": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+            "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true
         },
         "lodash.truncate": {
@@ -1495,15 +1514,66 @@
             }
         },
         "object.values": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.3.tgz",
-            "integrity": "sha512-nkF6PfDB9alkOUxpf1HNm/QlkeW3SReqL5WXeBLpEJJnlPSvRaDQpW3gQTksTN3fgJX4hL42RzKyOin6ff3tyw==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.4.tgz",
+            "integrity": "sha512-TnGo7j4XSnKQoK3MfvkzqKCi0nVe/D9I9IjwTNYdb/fxYHpjrluHVOgw0AF6jrRFGMPHdfuidR09tIDiIvnaSg==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.0-next.2",
-                "has": "^1.0.3"
+                "es-abstract": "^1.18.2"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.5",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.5.tgz",
+                    "integrity": "sha512-DDggyJLoS91CkJjgauM5c0yZMjiD1uK3KcaCeAmffGwZ+ODWzOkPN4QwRbsK5DOFf06fywmyLci3ZD8jLGhVYA==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "get-intrinsic": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.2",
+                        "internal-slot": "^1.0.3",
+                        "is-callable": "^1.2.3",
+                        "is-negative-zero": "^2.0.1",
+                        "is-regex": "^1.1.3",
+                        "is-string": "^1.0.6",
+                        "object-inspect": "^1.11.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.2",
+                        "string.prototype.trimend": "^1.0.4",
+                        "string.prototype.trimstart": "^1.0.4",
+                        "unbox-primitive": "^1.0.1"
+                    }
+                },
+                "is-regex": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+                    "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-tostringtag": "^1.0.0"
+                    }
+                },
+                "is-string": {
+                    "version": "1.0.7",
+                    "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+                    "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+                    "dev": true,
+                    "requires": {
+                        "has-tostringtag": "^1.0.0"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.11.0",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
+                    "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+                    "dev": true
+                }
             }
         },
         "once": {
@@ -1585,12 +1655,13 @@
             }
         },
         "parse-json": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+            "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
             "dev": true,
             "requires": {
-                "error-ex": "^1.2.0"
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
             }
         },
         "parse-semver": {
@@ -1644,18 +1715,18 @@
             "dev": true
         },
         "path-parse": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-            "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
         },
         "path-type": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-            "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+            "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "dev": true,
             "requires": {
-                "pify": "^2.0.0"
+                "pify": "^3.0.0"
             }
         },
         "pend": {
@@ -1665,15 +1736,24 @@
             "dev": true
         },
         "pify": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
             "dev": true
         },
         "pkg-dir": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+            "dev": true,
+            "requires": {
+                "find-up": "^2.1.0"
+            }
+        },
+        "pkg-up": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+            "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
             "dev": true,
             "requires": {
                 "find-up": "^2.1.0"
@@ -1722,24 +1802,24 @@
             }
         },
         "read-pkg": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-            "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
             "dev": true,
             "requires": {
-                "load-json-file": "^2.0.0",
+                "load-json-file": "^4.0.0",
                 "normalize-package-data": "^2.3.2",
-                "path-type": "^2.0.0"
+                "path-type": "^3.0.0"
             }
         },
         "read-pkg-up": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-            "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+            "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
             "dev": true,
             "requires": {
                 "find-up": "^2.0.0",
-                "read-pkg": "^2.0.0"
+                "read-pkg": "^3.0.0"
             }
         },
         "readable-stream": {
@@ -1758,9 +1838,9 @@
             }
         },
         "regexpp": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-            "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+            "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
             "dev": true
         },
         "require-from-string": {
@@ -1905,9 +1985,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
-            "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+            "version": "3.0.10",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.10.tgz",
+            "integrity": "sha512-oie3/+gKf7QtpitB0LYLETe+k8SifzsX4KixvpOsbI6S0kRiRQ5MKOio8eMSAKQ17N06+wdEOXRiId+zOxo0hA==",
             "dev": true
         },
         "sprintf-js": {
@@ -1987,14 +2067,13 @@
             }
         },
         "table": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.6.0.tgz",
-            "integrity": "sha512-iZMtp5tUvcnAdtHpZTWLPF0M7AgiQsURR2DwmxnJwSy8I3+cY+ozzVvYha3BOLG2TB+L0CqjIz+91htuj6yCXg==",
+            "version": "6.7.1",
+            "resolved": "https://registry.npmjs.org/table/-/table-6.7.1.tgz",
+            "integrity": "sha512-ZGum47Yi6KOOFDE8m223td53ath2enHcYLgOCjGr5ngu8bdIARQk6mN/wRMv4yMRcHnCSnHbCEha4sobQx5yWg==",
             "dev": true,
             "requires": {
                 "ajv": "^8.0.1",
                 "lodash.clonedeep": "^4.5.0",
-                "lodash.flatten": "^4.4.0",
                 "lodash.truncate": "^4.4.2",
                 "slice-ansi": "^4.0.0",
                 "string-width": "^4.2.0",
@@ -2002,9 +2081,9 @@
             },
             "dependencies": {
                 "ajv": {
-                    "version": "8.2.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.2.0.tgz",
-                    "integrity": "sha512-WSNGFuyWd//XO8n/m/EaOlNLtO0yL8EXT/74LqT4khdhpZjP7lkj/kT5uwRmGitKEVp/Oj7ZUHeGfPtgHhQ5CA==",
+                    "version": "8.6.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.2.tgz",
+                    "integrity": "sha512-9807RlWAgT564wT+DjeyU5OFMPjmzxVobvDFmNAhY+5zD6A2ly3jDp6sgnfyDtlIQ+7H97oc/DGCzzfu9rjw9w==",
                     "dev": true,
                     "requires": {
                         "fast-deep-equal": "^3.1.1",
@@ -2028,12 +2107,12 @@
             "dev": true
         },
         "tmp": {
-            "version": "0.0.29",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.29.tgz",
-            "integrity": "sha1-8lEl/w3Z2jzLDC3Tce4SiLuRKMA=",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
+            "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
             "dev": true,
             "requires": {
-                "os-tmpdir": "~1.0.1"
+                "rimraf": "^3.0.0"
             }
         },
         "traverse": {
@@ -2043,9 +2122,9 @@
             "dev": true
         },
         "tsconfig-paths": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
-            "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.11.0.tgz",
+            "integrity": "sha512-7ecdYDnIdmv639mmDwslG6KQg1Z9STTz1j7Gcz0xa+nshh/gKDAHcPxRbWOsA3SPp0tXP2leTcY9Kw+NAkfZzA==",
             "dev": true,
             "requires": {
                 "@types/json5": "^0.0.29",
@@ -2053,6 +2132,12 @@
                 "minimist": "^1.2.0",
                 "strip-bom": "^3.0.0"
             }
+        },
+        "tslib": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+            "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+            "dev": true
         },
         "tunnel": {
             "version": "0.0.6",
@@ -2070,15 +2155,15 @@
             }
         },
         "type-fest": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-            "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true
         },
         "typed-rest-client": {
-            "version": "1.8.4",
-            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.4.tgz",
-            "integrity": "sha512-MyfKKYzk3I6/QQp6e1T50py4qg+c+9BzOEl2rBmQIpStwNUoqQ73An+Tkfy9YuV7O+o2mpVVJpe+fH//POZkbg==",
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.8.5.tgz",
+            "integrity": "sha512-952/Aegu3lTqUAI1anbDLbewojnF/gh8at9iy1CIrfS1h/+MtNjB1Y9z6ZF5n2kZd+97em56lZ9uu7Zz3y/pwg==",
             "dev": true,
             "requires": {
                 "qs": "^6.9.1",
@@ -2087,9 +2172,9 @@
             }
         },
         "typescript": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-            "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+            "version": "4.4.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.2.tgz",
+            "integrity": "sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==",
             "dev": true
         },
         "uc.micro": {
@@ -2172,14 +2257,14 @@
             }
         },
         "vsce": {
-            "version": "1.88.0",
-            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.88.0.tgz",
-            "integrity": "sha512-FS5ou3G+WRnPPr/tWVs8b/jVzeDacgZHy/y7/QQW7maSPFEAmRt2bFGUJtJVEUDLBqtDm/3VGMJ7D31cF2U1tw==",
+            "version": "1.96.1",
+            "resolved": "https://registry.npmjs.org/vsce/-/vsce-1.96.1.tgz",
+            "integrity": "sha512-KnEVqjfc1dXrpZsbJ8J7B9VQ7GAAx8o5RqBNk42Srv1KF9+e2/aXchQHe9QZxeUs/FiliHoMGpGvnHTXwKIT2A==",
             "dev": true,
             "requires": {
-                "azure-devops-node-api": "^10.2.2",
+                "azure-devops-node-api": "^11.0.1",
                 "chalk": "^2.4.2",
-                "cheerio": "^1.0.0-rc.1",
+                "cheerio": "^1.0.0-rc.9",
                 "commander": "^6.1.0",
                 "denodeify": "^1.2.1",
                 "glob": "^7.0.6",
@@ -2192,7 +2277,7 @@
                 "parse-semver": "^1.1.1",
                 "read": "^1.0.7",
                 "semver": "^5.1.0",
-                "tmp": "0.0.29",
+                "tmp": "^0.2.1",
                 "typed-rest-client": "^1.8.4",
                 "url-join": "^1.1.0",
                 "yauzl": "^2.3.1",
@@ -2219,9 +2304,9 @@
             }
         },
         "vscode-test": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.5.2.tgz",
-            "integrity": "sha512-x9PVfKxF6EInH9iSFGQi0V8H5zIW1fC7RAer6yNQR6sy3WyOwlWkuT3I+wf75xW/cO53hxMi1aj/EvqQfDFOAg==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
+            "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
             "dev": true,
             "requires": {
                 "http-proxy-agent": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "workspace-explorer",
     "displayName": "Workspace Explorer",
     "description": "Browse, open, and manage your VSCode workspaces in this simple view.",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "icon": "resources/icons/icon.png",
     "publisher": "tomsaunders-code",
     "author": {
@@ -22,7 +22,7 @@
         "url": "https://github.com/sirfuzzalot/workspace-explorer.git"
     },
     "engines": {
-        "vscode": "^1.55.0"
+        "vscode": "^1.59.0"
     },
     "categories": [
         "Other"
@@ -39,6 +39,10 @@
         "*"
     ],
     "main": "./src/extension",
+    "extensionKind": [
+        "ui",
+        "workspace"
+    ],
     "contributes": {
         "configuration": {
             "type": "object",
@@ -277,22 +281,20 @@
         ]
     },
     "scripts": {
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "node ./node_modules/vscode/bin/test",
         "lint": "./node_modules/.bin/eslint ./src",
         "fix": "./node_modules/.bin/eslint --fix ./src",
         "build": "vsce package",
         "publish": "vsce publish"
     },
     "devDependencies": {
-        "@types/node": "^15.0.1",
-        "@types/vscode": "^1.55.0",
-        "eslint": "^7.25.0",
+        "@types/node": "^15.14.9",
+        "@types/vscode": "^1.59.0",
+        "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^14.2.1",
-        "eslint-plugin-import": "^2.22.1",
-        "typescript": "^4.2.4",
-        "vsce": "^1.88.0",
-        "vscode-test": "^1.5.2"
+        "eslint-plugin-import": "^2.24.2",
+        "typescript": "^4.4.2",
+        "vsce": "^1.96.1",
+        "vscode-test": "^1.6.1"
     },
     "eslintConfig": {
         "extends": "airbnb-base"

--- a/src/addSubFolder.js
+++ b/src/addSubFolder.js
@@ -24,8 +24,7 @@ const addSubFolder = async (context, treeDataProvider) => {
 
   let basePath = context ? context.workspaceFileNameAndFilePath : undefined;
   if (basePath === undefined) {
-    const config = vscode.workspace.getConfiguration('workspaceExplorer');
-    basePath = config.get('workspaceStorageDirectory');
+    basePath = treeDataProvider.workspaceStorageDirectory;
   }
 
   // Build new Directory path.


### PR DESCRIPTION
- Update extension config for remote development workflows. VSCode will first try to run the extension locally and fallback to the remote extension host. This enables desktop VSCode users to continue seeing their workspaces while using remote extensions.
- Patch a bug where folder creation would not work when running a remote extension
- Patch a bug where workspace creation would not work when running a remote extension

Closes #10

Closes #12